### PR TITLE
Fix height when using a smaller screen

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -34,7 +34,7 @@ function Home() {
         </div>
         <div
           css={css`
-            ${tw`h-full flex-grow flex-shrink`}
+            ${tw`h-full min-h-screen flex-grow flex-shrink`}
           `}
         >
           <div


### PR DESCRIPTION
When on a smaller screen, it cuts the bottom of the container which results in people not being able to see it.

An easy quick fix for this is to force the minimum height to be the screen.